### PR TITLE
refactor: drop unused default export from markdown converter

### DIFF
--- a/src/utils/markdownConverter.ts
+++ b/src/utils/markdownConverter.ts
@@ -165,5 +165,3 @@ const processListItems = (listElement: HTMLElement, marker: string): string => {
 
   return markdown;
 };
-
-export default convertToMarkdown; 


### PR DESCRIPTION
## Summary
- remove unneeded default export from markdownConverter

## Testing
- `npm test` *(fails: react-scripts not found)*